### PR TITLE
extending registration to support optional authentication

### DIFF
--- a/oidc_register/registration.py
+++ b/oidc_register/registration.py
@@ -89,7 +89,7 @@ class RegistrationError(Exception):
 
 
 # OpenID Connect Dynamic Client Registration 1.0
-def register_client(provider_info, redirect_uris):
+def register_client(provider_info, redirect_uris, auth_token=None):
     """
     This function registers a new client with the specified OpenID Provider,
     and then returns the regitered client ID and other information.
@@ -116,6 +116,8 @@ def register_client(provider_info, redirect_uris):
                    'token_endpoint_auth_method': 'client_secret_post'}
 
     headers = {'Content-type': 'application/json'}
+    if auth_token:
+        headers.update({'Authorization': 'Bearer ' + auth_token})
 
     resp, content = httplib2.Http().request(
         provider_info['registration_endpoint'], 'POST',

--- a/oidc_register/registration_util.py
+++ b/oidc_register/registration_util.py
@@ -46,6 +46,8 @@ def _parse_args():
                         help='Token introspection URI')
     parser.add_argument('--output-file', default='client_secrets.json',
                         help='File to write client info to')
+    parser.add_argument('-t', '--auth-token', default=None, dest="auth_token",
+                        help='Authentication Token; used when registration requires authentication.')
     parser.add_argument('--debug', action='store_true')
     return parser.parse_args()
 
@@ -77,7 +79,7 @@ def main():
         return 1
 
     try:
-        reg_info = registration.register_client(OP, redirect_uris)
+        reg_info = registration.register_client(OP, redirect_uris, auth_token=args.auth_token)
     except Exception as ex:
         print('Error registering client')
         if args.debug:


### PR DESCRIPTION
Without this you can't use these tools to register with endpoints that require authenticated registration. 

Fixes: https://github.com/puiterwijk/flask-oidc/issues/136 